### PR TITLE
Quick patch to constantly update currently playing song without requiring user interaction

### DIFF
--- a/src/scripts/StationList.js
+++ b/src/scripts/StationList.js
@@ -1,5 +1,5 @@
 /** ngInject **/
-function StationListCtrl($scope, EventBus, PvlService) {
+function StationListCtrl($scope, $interval, EventBus, PvlService) {
   let vm = this;
 
   vm.imgUrls = {};
@@ -7,6 +7,8 @@ function StationListCtrl($scope, EventBus, PvlService) {
   vm.currentIndex = null;
   vm.setSelected = setSelected;
 
+  var refreshDataBindings = $interval(null, 1000);
+  
   function setSelected(index) {
     vm.currentIndex = index;
     EventBus.emit('pvl:stationSelect', vm.stations[index]);
@@ -21,6 +23,7 @@ function StationListCtrl($scope, EventBus, PvlService) {
 
   let unsubNowPlaying = EventBus.on('pvl:nowPlaying', nowPlayingListener);
   $scope.$on('$destroy', () => {
+	$interval.cancel(refreshDataBindings);
     unsubNowPlaying();
   });
 }


### PR DESCRIPTION
This is a patch that address the issue Auzzie reported on the Chrome Web Store's support tab for the app:

"The station info isn't set to update automatically, only happens when I click on the station again"

I've added a call to $interval with no function body to simply force the associated $apply() to fire every second.

I'm new to Angular. There may very well be a cleaner way to do this and I'm also not sure if I'm calling $interval.cancel() properly (or how to test it, for that matter), but I've built the code with the additions and everything seems to work properly. Polling every second may also be overkill.

I did this to fix the issue for myself, since it was a bit annoying, and figured I may as well offer it back upstream. Won't hurt my feelings a bit if you decide this is too "quick and dirty" of a patch to incorporate back into the main branch. ;)
