### PR TITLE
Revert "Quick patch to constantly update currently playing song without ...

### DIFF
--- a/src/scripts/StationList.js
+++ b/src/scripts/StationList.js
@@ -1,5 +1,5 @@
 /** ngInject **/
-function StationListCtrl($scope, $interval, EventBus, PvlService) {
+function StationListCtrl($scope, EventBus, PvlService) {
   let vm = this;
 
   vm.imgUrls = {};
@@ -7,8 +7,6 @@ function StationListCtrl($scope, $interval, EventBus, PvlService) {
   vm.currentIndex = null;
   vm.setSelected = setSelected;
 
-  var refreshDataBindings = $interval(null, 1000);
-  
   function setSelected(index) {
     vm.currentIndex = index;
     EventBus.emit('pvl:stationSelect', vm.stations[index]);
@@ -23,7 +21,6 @@ function StationListCtrl($scope, $interval, EventBus, PvlService) {
 
   let unsubNowPlaying = EventBus.on('pvl:nowPlaying', nowPlayingListener);
   $scope.$on('$destroy', () => {
-	$interval.cancel(refreshDataBindings);
     unsubNowPlaying();
   });
 }


### PR DESCRIPTION
Turns out this patch does not work properly if the app's window is minimized/loses focus. The station list continues to update properly but the media player pane does not.

Please consider using the alternative code (in the following pull request) instead.
